### PR TITLE
Pose averaging

### DIFF
--- a/include/cmr_geometry_utils/pose.hpp
+++ b/include/cmr_geometry_utils/pose.hpp
@@ -1,21 +1,15 @@
-#pragma once
+// #pragma once
 
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_with_covariance.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 
 #include "quaternion.hpp"
 
 namespace cmr_geometry_utils {
 namespace pose {
-    void average(std::vector<geometry_msgs::msg::Pose> poses, geometry_msgs::msg::Pose& average_pose, std::vector<double> weights = {}){
-        if(weights.size() != 0 && pose.size() != weights.size()){
-            throw std::invalid_argument("poses and weights arrays should be of the same size OR weights should be empty");
-            return;
-        }
-
+    inline void average(std::vector<geometry_msgs::msg::Pose> poses, geometry_msgs::msg::Pose& average_pose){
         std::vector<geometry_msgs::msg::Quaternion> quats;
-        double average_x = 0.0;
-        double average_y = 0.0;
         for(auto& pose : poses){
             average_pose.position.x += pose.position.x;
             average_pose.position.y += pose.position.y;
@@ -27,7 +21,15 @@ namespace pose {
         average_pose.position.y /= poses.size();
 
         
-        cmr_geometry_utils::quaternion::average(quats, average_pose.orientation, weights);
+        cmr_geometry_utils::quaternion::average(quats, average_pose.orientation);
+    }
+
+    inline void average(std::vector<geometry_msgs::msg::PoseWithCovariance> poses_with_covariance, geometry_msgs::msg::Pose& average_pose){
+        std::vector<geometry_msgs::msg::Pose> poses;
+        for(auto& pose : poses_with_covariance){
+            poses.push_back(pose.pose);
+        }
+        average(poses, average_pose);
     }
 } // pose
 } // cmr_geometry_utils

--- a/include/cmr_geometry_utils/pose.hpp
+++ b/include/cmr_geometry_utils/pose.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+
+#include "quaternion.hpp"
+
+namespace cmr_geometry_utils {
+namespace pose {
+    void average(std::vector<geometry_msgs::msg::Pose> poses, geometry_msgs::msg::Pose& average_pose, std::vector<double> weights = {}){
+        if(weights.size() != 0 && pose.size() != weights.size()){
+            throw std::invalid_argument("poses and weights arrays should be of the same size OR weights should be empty");
+            return;
+        }
+
+        std::vector<geometry_msgs::msg::Quaternion> quats;
+        double average_x = 0.0;
+        double average_y = 0.0;
+        for(auto& pose : poses){
+            average_pose.position.x += pose.position.x;
+            average_pose.position.y += pose.position.y;
+
+            quats.push_back(pose.orientation);
+        }
+
+        average_pose.position.x /= poses.size();
+        average_pose.position.y /= poses.size();
+
+        
+        cmr_geometry_utils::quaternion::average(quats, average_pose.orientation, weights);
+    }
+} // pose
+} // cmr_geometry_utils

--- a/include/cmr_geometry_utils/quaternion.hpp
+++ b/include/cmr_geometry_utils/quaternion.hpp
@@ -1,11 +1,47 @@
 #pragma once
 
 #include <geometry_msgs/msg/quaternion.hpp>
+#include <Eigen/SVD>
 
 namespace cmr_geometry_utils {
 namespace quaternion {
-    void average(std::vector<geometry_msgs::msg::Quaternion> quats, geometry_msgs::msg::Quaternion& average_quaternion, std::vector<double> weights = {}){
+    inline void msg2eigen(geometry_msgs::msg::Quaternion q_msg, Eigen::Vector4f& q_eig){
+        q_eig[0] = q_msg.x;
+        q_eig[1] = q_msg.y;
+        q_eig[2] = q_msg.z;
+        q_eig[3] = q_msg.w;
+    }
 
+    inline void average(
+        std::vector<geometry_msgs::msg::Quaternion> quats
+        , geometry_msgs::msg::Quaternion& average_quaternion){
+
+        Eigen::Matrix4f A = Eigen::Matrix4f::Zero();
+
+        for (auto& q_msg : quats){
+            Eigen::Vector4f q;
+            msg2eigen(q_msg, q);
+
+            A += q * q.transpose();
+        }
+
+        // normalise with the number of quaternions
+        A /= quats.size();
+
+        // Compute the SVD of this 4x4 matrix
+        Eigen::JacobiSVD<Eigen::MatrixXf> svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+        Eigen::MatrixXf U = svd.matrixU();
+
+        // find the eigen vector corresponding to the largest eigen value.
+        // according to Eigen doc, singular values sorted in descending order 
+        // i.e. the first singular vector corresponds to the largest singular value
+        size_t largestEigenValueIndex = 0;
+
+        Eigen::Vector4f average;
+        average_quaternion.x = U(0, largestEigenValueIndex);
+        average_quaternion.y = U(1, largestEigenValueIndex);
+        average_quaternion.z = U(2, largestEigenValueIndex);
+        average_quaternion.w = U(3, largestEigenValueIndex);
     }
 } // quaternion
 } // cmr_geometry_utils

--- a/include/cmr_geometry_utils/quaternion.hpp
+++ b/include/cmr_geometry_utils/quaternion.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <geometry_msgs/msg/quaternion.hpp>
+
+namespace cmr_geometry_utils {
+namespace quaternion {
+    void average(std::vector<geometry_msgs::msg::Quaternion> quats, geometry_msgs::msg::Quaternion& average_quaternion, std::vector<double> weights = {}){
+
+    }
+} // quaternion
+} // cmr_geometry_utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,13 @@ target_link_libraries(basic_geometry_test
 ament_target_dependencies(basic_geometry_test ${dependencies})
 target_include_directories(basic_geometry_test PRIVATE "../include" "include" ${${TESTS_UTILS_PROJECT}_INCLUDE_DIRS})
 
+ament_add_gtest(pose_geometry_test pose_geometry_test.cpp)
+target_link_libraries(pose_geometry_test
+  cmr_geometry_utils_lib
+)
+ament_target_dependencies(pose_geometry_test ${dependencies})
+target_include_directories(pose_geometry_test PRIVATE "../include" "include" ${${TESTS_UTILS_PROJECT}_INCLUDE_DIRS})
+
 
 # ament_add_gtest(transforms_test transforms_test.cpp)
 # target_link_libraries(transforms_test

--- a/test/pose_geometry_test.cpp
+++ b/test/pose_geometry_test.cpp
@@ -1,0 +1,13 @@
+#include "cmr_geometry_utils/pose.hpp"
+
+#include <gtest/gtest.h>
+#include <geometry_msgs/msg/pose.hpp>
+
+TEST(PoseGeometryTest, calculate_average_pose)
+{
+    geometry_msgs::msg::Pose p;
+    std::vector<geometry_msgs::msg::Pose> v = {};
+    cmr_geometry_utils::pose::average(v, p);
+
+    ASSERT_EQ(p.position.x, 1234);
+}

--- a/test/pose_geometry_test.cpp
+++ b/test/pose_geometry_test.cpp
@@ -6,8 +6,38 @@
 TEST(PoseGeometryTest, calculate_average_pose)
 {
     geometry_msgs::msg::Pose p;
-    std::vector<geometry_msgs::msg::Pose> v = {};
+
+    geometry_msgs::msg::Pose p1;
+    p1.position.x = 0.0;
+    p1.position.y = 0.0;
+    p1.position.z = 0.0;
+
+    p1.orientation.x = 0.0;
+    p1.orientation.y = 0.0;
+    p1.orientation.z = 0.0;
+    p1.orientation.w = 1.0;
+
+    geometry_msgs::msg::Pose p2;
+    p1.position.x = 20.0;
+    p1.position.y = 10.0;
+    p1.position.z = 0.0;
+
+    p1.orientation.x = 0.8788171;
+    p1.orientation.y = 0.0;
+    p1.orientation.z = 0.0;
+    p1.orientation.w = 0.4771588;
+
+
+
+    std::vector<geometry_msgs::msg::Pose> v = {p1, p2};
     cmr_geometry_utils::pose::average(v, p);
 
-    ASSERT_EQ(p.position.x, 1234);
+    ASSERT_EQ(p.position.x, 10.);
+    ASSERT_EQ(p.position.y, 5.);
+    ASSERT_EQ(p.position.z, 0.0);
+    
+    ASSERT_NEAR(p.orientation.x, 0.5112, 1e-4);
+    ASSERT_EQ(p.orientation.y, 0.0);
+    ASSERT_EQ(p.orientation.z, 0.0);
+    ASSERT_NEAR(p.orientation.w, 0.8594, 1e-4);
 }


### PR DESCRIPTION
## Purpose
Average a set of poses.

## Approach
Calculation for average translation and orientation is done separately: 
- average translation is just an average for `x` and `y` coordinates
- averaging quaternions is a bit tricky, so I used method from here: https://ntrs.nasa.gov/citations/20070017872. 