### PR TITLE
fix: pose average z coord becomes zero

### DIFF
--- a/include/cmr_geometry_utils/pose.hpp
+++ b/include/cmr_geometry_utils/pose.hpp
@@ -14,12 +14,14 @@ namespace pose {
         for(const auto& pose : poses){
             average_pose.position.x += pose.position.x;
             average_pose.position.y += pose.position.y;
+            average_pose.position.z += pose.position.z;
 
             quats.push_back(pose.orientation);
         }
 
         average_pose.position.x /= poses.size();
         average_pose.position.y /= poses.size();
+        average_pose.position.z /= poses.size();
 
         
         cmr_geometry_utils::quaternion::average(quats, average_pose.orientation);


### PR DESCRIPTION
## Purpose
Z coordinate being ignored, and was causing problems for camera calibration with the use of fiducials. 

Normally this doesn't matter in production, as poses meant to be averaged are in base_footprint frame, which always have z=0